### PR TITLE
Use cwltool installed directly via pip

### DIFF
--- a/dx-cwl
+++ b/dx-cwl
@@ -386,7 +386,6 @@ def compile_tool_internal(tool, assets, folder='/', extradisk=10000):
 
     sh("rm -rf {}".format(dirname))
     makedirs(dirname+"/resources/home/dnanexus")
-    sh("cp -r cwltool {}/resources/home/dnanexus".format(dirname))
     sh("cp {} {}/resources/home/dnanexus/tool.cwl".format(tool, dirname))
     sh("cp {}/dx-cwl-applet-code.py {}".format(script_dir, dirname))
     tool = load_raw_tool(tool)
@@ -619,7 +618,6 @@ def compile_inline_js_wf_input(workflow_fname, sname, step, folder, i, sources):
                            folder[1:], os.path.splitext(os.path.basename(workflow_fname))[0], applet_name)
     sh("rm -rf {}".format(dirname))
     makedirs(dirname+"/resources/home/dnanexus")
-    sh("cp -r cwltool {}/resources/home/dnanexus".format(dirname))
     if 'valueFrom' in i:
         with open("{}/resources/home/dnanexus/expression.txt".format(dirname), "w") as f:
             f.write(i['valueFrom'])
@@ -771,13 +769,13 @@ def shell_suppress(cmd, ignore_error=False):
 def compile_postprocess_tool(workflow, outputs, folder='/'):
     applet_name = "postprocess-outputs"
     dirname = os.path.splitext(workflow)[0]+"/"+applet_name
-    sh("sudo rm -rf {}".format(dirname))
+    sh("rm -rf {}".format(dirname))
     makedirs(dirname+"/resources/home/dnanexus")
     with open(dirname+"/resources/home/dnanexus/output_folder.txt", "w") as f:
         f.write(folder+"-output")
 
     # TODO: Improve modularity of this
-    sh("cp dx-cwl-postprocess-output-code.py {dir}".format(dir=dirname))
+    sh("cp {script_dir}/dx-cwl-postprocess-output-code.py {dir}".format(script_dir=script_dir, dir=dirname))
 
     dxapp = {}
 
@@ -845,7 +843,7 @@ def compile_workflow_internal(workflow_fname, assets, token, project):
 
 
     wfname = workflow_name(workflow_fname)
-    folder = "/dx-cwl-prep/"+wfname
+    folder = "/dx-cwl-run/"+wfname
     dx_mkdir_archive(folder, ".cwl_workflow_archive")
 
     print "Compiling tools/workflows for each step in the workflow"

--- a/dx-cwl-applet-code.py
+++ b/dx-cwl-applet-code.py
@@ -5,6 +5,8 @@ import yaml
 import subprocess
 from pprint import pprint
 
+CWLTOOL_VERSION = "1.0.20171017195544"
+
 # TODO: potentially pull these out to common utilities
 def sh(cmd, ignore_error=False):
     try:
@@ -30,10 +32,9 @@ def shell_suppress(cmd, ignore_error=False):
 
 @dxpy.entry_point('main')
 def main(**kwargs):
-    print "Installing custom cwltool"
+    print "Installing cwltool"
     sh("pip install -U pip wheel setuptools")
-    sh("cd cwltool/ && python setup.py install > /dev/null 2>&1 && cd ..")
-    sh("cd cwltool/cwlref-runner && python setup.py install > /dev/null 2>&1 && cd ../../")
+    sh("pip install cwltool=={}".format(CWLTOOL_VERSION))
     sh("curl https://nodejs.org/dist/v6.11.2/node-v6.11.2-linux-x64.tar.gz | tar xzvf - --strip-components 1 -C /usr/local/ > /dev/null")
 
     print("Download inputs and create CWL file")
@@ -93,7 +94,7 @@ def main(**kwargs):
     pprint(cwlinputs)
 
     print("Running CWL tool")
-    sh("cwl-runner --user-space-docker-cmd dx-docker tool.cwl cwlinputs.yml > cwl_job_outputs.json")
+    sh("cwltool --user-space-docker-cmd dx-docker tool.cwl cwlinputs.yml > cwl_job_outputs.json")
 
     print("Process CWL outputs")
     output = {}


### PR DESCRIPTION
- Avoids need for downloading specific cwltool locally, instead
  installing supported version via pip during runs.
- Change name of CWL directory to `dx-cwl-run` to reflect that it
  includes run information and outputs