### PR TITLE
Resync package index when initializing applet instance

### DIFF
--- a/dx-cwl-applet-code.py
+++ b/dx-cwl-applet-code.py
@@ -32,6 +32,7 @@ def shell_suppress(cmd, ignore_error=False):
 
 @dxpy.entry_point('main')
 def main(**kwargs):
+    sh("apt-get update")
     sh("apt-get install python-virtualenv samtools")
     sh("git clone --recursive https://github.com/dnanexus/dx-toolkit.git")
     sh("cd dx-toolkit && git checkout 0c818a5cce7164119e7a89d7415770e1ff2caece && cd ..")


### PR DESCRIPTION
Installing packages would always fail since the index was
outdated/nonexistent.

```
apt-get install python-virtualenv samtools
Reading package lists...
Building dependency tree...
Reading state information...
Package python-virtualenv is not available, but is referred to by
another package.
This may mean that the package is missing, has been obsoleted, or
is only available from another source
E: Package 'python-virtualenv' has no installation candidate
E: Unable to locate package samtools
```