### PR TITLE
strip_prefix: re-add file open for skip_downloads case

### DIFF
--- a/dx-cwl-applet-code.py
+++ b/dx-cwl-applet-code.py
@@ -144,7 +144,7 @@ def main(**kwargs):
                     return dxpy.dxlink(dxpy.upload_local_file(remove_prefix(ovalue['location'], "file://"), wait_on_close=True, project=dxpy.PROJECT_CONTEXT_ID, folder=folder))
 
                 if skip_downloads:
-                    files = dxpy.dxlink(remove_prefix(ovalue['location'], "file://").read().rstrip())
+                    files = dxpy.dxlink(open(remove_prefix(ovalue['location'], "file://")).read().rstrip())
                 else:
                     files = upload_file(ovalue)
                 if 'secondaryFiles' in ovalue:


### PR DESCRIPTION
Adding the general strip_prefix inadvertently removed the open
for reading file contents
(https://github.com/dnanexus/dx-cwl/commit/8e00129e866196b0d26d82257b807c66549aa75c#diff-2db7e5b332534bdad086f734c92c99cdR147)